### PR TITLE
Update IRequestInfo.kt

### DIFF
--- a/src/main/kotlin/burp/IRequestInfo.kt
+++ b/src/main/kotlin/burp/IRequestInfo.kt
@@ -31,7 +31,7 @@ interface IRequestInfo {
      *
      * @return The URL in the request.
      */
-    val url: URL
+    val url: URL?
 
     /**
      * This method is used to obtain the HTTP headers contained in the request.


### PR DESCRIPTION
I know it doesn't say that in the official Burp API, but the URL can actually be null if you do invalid modifications in Burp Repeater and then the URL parsing breaks.